### PR TITLE
remove unused variables in preSave

### DIFF
--- a/src/GeocodableBehavior.php
+++ b/src/GeocodableBehavior.php
@@ -80,9 +80,7 @@ const NAUTICAL_MILES_UNIT = 0.8684;
         if ('false' === $this->getParameter('auto_update')) {
           return "";
         }
-        $script = "if( (\$update_latitude = !\$this->isColumnModified(" . $this->getColumnConstant('latitude_column', $builder) . ")) &&
-    (\$update_longitude = !\$this->isColumnModified(" . $this->getColumnConstant('longitude_column', $builder) . "))
-    ) {
+        $script = "if (!\$this->isColumnModified(" . $this->getColumnConstant('latitude_column', $builder) . ") && !\$this->isColumnModified(" . $this->getColumnConstant('longitude_column', $builder) . ")) {
     \$this->geocode();
 }
 ";


### PR DESCRIPTION
It also makes the code more readable.

Before:

``` php
<?php
  // ...

  // geocodable behavior
  if( ($update_latitude = !$this->isColumnModified(AddressPeer::LATITUDE)) &&
      ($update_longitude = !$this->isColumnModified(AddressPeer::LONGITUDE))
      ) {
      $this->geocode();
  }

  // ..
```

After:

``` php
<?php
  // ...

  // geocodable behavior
  if (!$this->isColumnModified(AddressPeer::LATITUDE) && !$this->isColumnModified(AddressPeer::LONGITUDE)) {
      $this->geocode();
  }

  // ..
```
