### PR TITLE
add more extension points for child classes

### DIFF
--- a/src/GeocodableBehavior.php
+++ b/src/GeocodableBehavior.php
@@ -75,10 +75,7 @@ class GeocodableBehavior extends Behavior
             return '';
         }
 
-        return $this->renderTemplate('objectPreSave', array(
-            'longitudeColumnConstant'   => $this->getColumnConstant('longitude_column', $builder),
-            'latitudeColumnConstant'    => $this->getColumnConstant('latitude_column', $builder),
-        ));
+        return $this->renderTemplate('objectPreSave');
     }
 
     public function objectMethods($builder)
@@ -153,7 +150,7 @@ class GeocodableBehavior extends Behavior
                 }
             }
 
-            $script .= $this->renderTemplate('objectGeocode', array(
+            $templateOptions = array(
                 'apiKeyProvider'    => $apiKeyProvider,
                 'apiKey'            => $apiKey,
                 'columns'           => $columns,
@@ -165,7 +162,17 @@ class GeocodableBehavior extends Behavior
                 'geocoderAdapter'   => $this->getParameter('geocoder_adapter'),
                 'latitudeSetter'    => $this->getColumnSetter('latitude_column'),
                 'longitudeSetter'   => $this->getColumnSetter('longitude_column'),
-            ));
+                'longitudeColumnConstant'   => $this->getColumnConstant('longitude_column', $builder),
+                'latitudeColumnConstant'    => $this->getColumnConstant('latitude_column', $builder),
+            );
+
+            $script .= $this->renderTemplate('objectGetGeocoder', $templateOptions);
+            $script .= $this->renderTemplate('objectGeocode', $templateOptions);
+            if ($templateOptions['geocodeAddress']) {
+                $script .= $this->renderTemplate('objectGetAddressParts', $templateOptions);
+                $script .= $this->renderTemplate('objectHasAddressChanged', $templateOptions);
+            }
+            $script .= $this->renderTemplate('objectIsGeocodingNecessary', $templateOptions);
         } else {
             $script .= $this->renderTemplate('objectGeocodeEmpty');
         }

--- a/src/templates/objectGeocode.php
+++ b/src/templates/objectGeocode.php
@@ -1,28 +1,13 @@
 
 /**
  * Update geocode information.
- * You can extend this method to fill in other fields.
  *
- * @return \Geocoder\GeocodedResult\GeocodedResultInterface|null
+ * @return \Geocoder\Result\ResultInterface|null
  */
 public function geocode()
 {
-    $geocodedResult   = null;
-<?php if ($geocodeAddress) : ?>
-    $address_parts    = array();
-    $address_modified = false;
-
-<?php foreach ($columns as $constantName => $phpName) : ?>
-    // <?php echo $phpName . "\n" ?>
-    $address_modified = $address_modified || $this->isColumnModified(<?php echo $constantName ?>);
-    $address_parts['<?php echo strtolower($phpName) ?>'] = $this->get<?php echo ucfirst($phpName) ?>();
-
-<?php endforeach; ?>
-<?php endif; ?>
-<?php if ($apiKeyProvider) : ?>
-    $provider = new <?php echo $apiKeyProvider ?>;
-<?php endif; ?>
-    $geocoder = new \Geocoder\Geocoder(new <?php echo $geocoderProvider ?>(new <?php echo $geocoderAdapter ?>()<?php echo $apiKey ?>));
+    $geocodedResult = null;
+    $geocoder = $this->getGeocoder();
 
 <?php if ($geocodeIp) : ?>
     if ($this->isColumnModified(<?php echo $ipColumnConstant ?>)) {
@@ -31,14 +16,13 @@ public function geocode()
 
 <?php endif; ?>
 <?php if ($geocodeAddress) : ?>
-    if ($address = join(',', array_filter($address_parts))) {
+    if ($this->hasAddressChanged() && $address = join(',', array_filter($this->getAddressParts()))) {
         $geocodedResult = $geocoder->geocode($address);
     }
 
 <?php endif; ?>
     if (null !== $geocodedResult && $coordinates = $geocodedResult->getCoordinates()) {
-        $this-><?php echo $latitudeSetter ?>($coordinates[0]);
-        $this-><?php echo $longitudeSetter ?>($coordinates[1]);
+        $this->setCoordinates($coordinates[0], $coordinates[1]);
     }
 
     return $geocodedResult;

--- a/src/templates/objectGetAddressParts.php
+++ b/src/templates/objectGetAddressParts.php
@@ -1,0 +1,19 @@
+
+/**
+ * Retrieve the address parts to be geocoded.
+ *
+ * You can extend this method to fill in other fields.
+ *
+ * @return array
+ */
+public function getAddressParts()
+{
+    $parts    = array();
+<?php foreach ($columns as $constantName => $phpName) : ?>
+    // <?php echo $phpName . "\n" ?>
+    $parts['<?php echo strtolower($phpName) ?>'] = $this->get<?php echo ucfirst($phpName) ?>();
+
+<?php endforeach; ?>
+
+    return $parts;
+}

--- a/src/templates/objectGetGeocoder.php
+++ b/src/templates/objectGetGeocoder.php
@@ -1,0 +1,24 @@
+
+/**
+ * Return a geocoder to be used to geocode the objects information.
+ *
+ * @return \Geocoder\GeocoderInterface
+ */
+public function getGeocoder()
+{
+<?php
+/**
+ * In case the $apiKeyProvider is set the $apiKey will contain "$provider->getApiKey()" or other executable code.
+ *
+ * Don't remove the "new";
+ * for static methods the $apiKeyProvider is false, but the $apiKey contains executable code as well e.g. "GeoApiKeyProvider::getKey()".
+ *
+ * @see GeocodableBehavior::objectMethods()
+ */
+if ($apiKeyProvider) :  ?>
+    $provider = new <?php echo $apiKeyProvider ?>;
+<?php endif; ?>
+    $geocoder = new \Geocoder\Geocoder(new <?php echo $geocoderProvider ?>(new <?php echo $geocoderAdapter ?>()<?php echo $apiKey ?>));
+
+    return $geocoder;
+}

--- a/src/templates/objectHasAddressChanged.php
+++ b/src/templates/objectHasAddressChanged.php
@@ -1,0 +1,16 @@
+
+/**
+ * Check whether the address of this object has changed.
+ *
+ * @return boolean
+ */
+public function hasAddressChanged()
+{
+    $changed = false;
+<?php foreach ($columns as $constantName => $phpName) : ?>
+    // <?php echo $phpName . "\n" ?>
+    $changed = $changed || $this->isColumnModified(<?php echo $constantName ?>);
+<?php endforeach; ?>
+
+    return $changed;
+}

--- a/src/templates/objectIsGeocodingNecessary.php
+++ b/src/templates/objectIsGeocodingNecessary.php
@@ -1,0 +1,10 @@
+
+/**
+ * Check whether the current object is required to be geocoded (again).
+ *
+ * @return boolean
+ */
+public function isGeocodingNecessary()
+{
+    return !$this->isColumnModified(<?php echo $latitudeColumnConstant ?>) && !$this->isColumnModified(<?php echo $longitudeColumnConstant ?>);
+}

--- a/src/templates/objectPreSave.php
+++ b/src/templates/objectPreSave.php
@@ -1,4 +1,4 @@
 
-if (!$this->isColumnModified(<?php echo $latitudeColumnConstant ?>) && !$this->isColumnModified(<?php echo $longitudeColumnConstant ?>)) {
+if ($this->isGeocodingNecessary()) {
     $this->geocode();
 }


### PR DESCRIPTION
Those methods allow to customize the object without necessarily overwriting the complete `geocode` method.

For example, this is now possible (`Zipcode`, `City`, `Region`, `Country` being related objects):

``` php
<?php

class Address extends BaseAddress
{
    /**
     * Retrieve the address parts to be geocoded.
     *
     * You can extend this method to fill in other fields.
     *
     * @return array
     */
    public function getAddressParts()
    {
        $parts = array();
        $parts['street']  = (string) $this->getStreet();
        $parts['zipcode'] = (string) $this->getZipcode();
        $parts['city']    = (string) $this->getCity();
        $parts['region']  = (string) $this->getRegion();
        $parts['country'] = (string) $this->getCountry();

        return $parts;
    }
}
```
