### PR TITLE
Fix missing IsGeocodingNecessary method when no geocoder is set

### DIFF
--- a/src/GeocodableBehavior.php
+++ b/src/GeocodableBehavior.php
@@ -113,7 +113,13 @@ class GeocodableBehavior extends Behavior
             'longitudeGetter' => $this->getColumnGetter('longitude_column'),
         ));
 
-        if ('true' === $this->getParameter('geocode_ip') || 'true' === $this->getParameter('geocode_address')) {
+        $templateOptions = array(
+            'geocodeIp'         => 'true' === $this->getParameter('geocode_ip'),
+            'geocodeAddress'    => 'true' === $this->getParameter('geocode_address') && '' !== $this->getParameter('address_columns'),
+        );
+
+        if ($templateOptions['geocodeIp'] || $templateOptions['geocodeAddress']) {
+
             $apiKey = '';
             $apiKeyProvider = false;
 
@@ -150,12 +156,10 @@ class GeocodableBehavior extends Behavior
                 }
             }
 
-            $templateOptions = array(
+            $templateOptions = array_merge($templateOptions, array(
                 'apiKeyProvider'    => $apiKeyProvider,
                 'apiKey'            => $apiKey,
                 'columns'           => $columns,
-                'geocodeIp'         => 'true' === $this->getParameter('geocode_ip'),
-                'geocodeAddress'    => 'true' === $this->getParameter('geocode_address') && '' !== $this->getParameter('address_columns'),
                 'ipColumnConstant'  => 'true' === $this->getParameter('geocode_ip') ? $this->getColumnConstant('ip_column', $builder) : '',
                 'ipColumnGetter'    => 'true' === $this->getParameter('geocode_ip') ? $this->getColumnGetter('ip_column') : '',
                 'geocoderProvider'  => $this->getParameter('geocoder_provider'),
@@ -164,7 +168,7 @@ class GeocodableBehavior extends Behavior
                 'longitudeSetter'   => $this->getColumnSetter('longitude_column'),
                 'longitudeColumnConstant'   => $this->getColumnConstant('longitude_column', $builder),
                 'latitudeColumnConstant'    => $this->getColumnConstant('latitude_column', $builder),
-            );
+            ));
 
             $script .= $this->renderTemplate('objectGetGeocoder', $templateOptions);
             $script .= $this->renderTemplate('objectGeocode', $templateOptions);
@@ -172,10 +176,11 @@ class GeocodableBehavior extends Behavior
                 $script .= $this->renderTemplate('objectGetAddressParts', $templateOptions);
                 $script .= $this->renderTemplate('objectHasAddressChanged', $templateOptions);
             }
-            $script .= $this->renderTemplate('objectIsGeocodingNecessary', $templateOptions);
         } else {
             $script .= $this->renderTemplate('objectGeocodeEmpty');
         }
+
+        $script .= $this->renderTemplate('objectIsGeocodingNecessary', $templateOptions);
 
         return $script;
     }

--- a/src/templates/objectIsGeocodingNecessary.php
+++ b/src/templates/objectIsGeocodingNecessary.php
@@ -5,7 +5,8 @@
  * @return boolean
  */
 public function isGeocodingNecessary()
-{<?php if ($geocodeIp || $geocodeAddress): ?>
+{
+<?php if ($geocodeIp || $geocodeAddress): ?>
     return !$this->isColumnModified(<?php echo $latitudeColumnConstant ?>) && !$this->isColumnModified(<?php echo $longitudeColumnConstant ?>);
 <?php else: ?>
     return false;

--- a/src/templates/objectIsGeocodingNecessary.php
+++ b/src/templates/objectIsGeocodingNecessary.php
@@ -5,6 +5,9 @@
  * @return boolean
  */
 public function isGeocodingNecessary()
-{
+{<?php if ($geocodeIp || $geocodeAddress): ?>
     return !$this->isColumnModified(<?php echo $latitudeColumnConstant ?>) && !$this->isColumnModified(<?php echo $longitudeColumnConstant ?>);
+<?php else: ?>
+    return false;
+<?php endif; ?>
 }

--- a/tests/GeocodableBehaviorTest.php
+++ b/tests/GeocodableBehaviorTest.php
@@ -137,6 +137,7 @@ EOF;
         $this->assertTrue(method_exists('GeocodedObject', 'getLongitude'));
         $this->assertTrue(method_exists('GeocodedObject', 'geocode'));
         $this->assertTrue(method_exists('GeocodedObject', 'isGeocoded'));
+        $this->assertTrue(method_exists('GeocodedObject', 'isGeocodingNecessary'));
         $this->assertTrue(method_exists('GeocodedObject', 'getDistanceTo'));
         $this->assertTrue(method_exists('GeocodedObject', 'getCoordinates'));
         $this->assertTrue(method_exists('GeocodedObject', 'setCoordinates'));

--- a/tests/GeocodableBehaviorWithNamespacesTest.php
+++ b/tests/GeocodableBehaviorWithNamespacesTest.php
@@ -146,6 +146,7 @@ EOF;
         $this->assertTrue(method_exists('My\GeocodedObject2', 'getLongitude'));
         $this->assertTrue(method_exists('My\GeocodedObject2', 'geocode'));
         $this->assertTrue(method_exists('My\GeocodedObject2', 'isGeocoded'));
+        $this->assertTrue(method_exists('My\GeocodedObject2', 'isGeocodingNecessary'));
         $this->assertTrue(method_exists('My\GeocodedObject2', 'getDistanceTo'));
         $this->assertTrue(method_exists('My\GeocodedObject2', 'getCoordinates'));
         $this->assertTrue(method_exists('My\GeocodedObject2', 'setCoordinates'));


### PR DESCRIPTION
Sample use case: I got coordinates from a sensor (so no required geocoder) and just need to access to distance computation methods. 
