### PR TITLE
fix filterByDistanceFrom(..)

### DIFF
--- a/src/templates/queryFilterByDistanceFrom.php
+++ b/src/templates/queryFilterByDistanceFrom.php
@@ -12,8 +12,27 @@
  */
 public function filterByDistanceFrom($latitude, $longitude, $distance, $unit = <?php echo $defaultUnit ?>, $comparison = Criteria::LESS_THAN)
 {
+    if (<?php echo $peerClassName ?>::MILES_UNIT === $unit) {
+        $earthRadius = 3959;
+    } elseif (<?php echo $peerClassName ?>::NAUTICAL_MILES_UNIT === $unit) {
+        $earthRadius = 3440;
+    } else {
+        $earthRadius = 6371;
+    }
+
+    $sql = 'ABS(%s * ACOS(%s * COS(RADIANS(%s)) * COS(RADIANS(%s) - %s) + %s * SIN(RADIANS(%s))))';
+    $preparedSql = sprintf($sql,
+        $earthRadius,
+        cos(deg2rad($latitude)),
+        $this->getAliasedColName(<?php echo $latitudeColumnConstant ?>),
+        $this->getAliasedColName(<?php echo $longitudeColumnConstant ?>),
+        deg2rad($longitude),
+        sin(deg2rad($latitude)),
+        $this->getAliasedColName(<?php echo $latitudeColumnConstant ?>)
+    );
+
     return $this
-        ->withDistance($latitude, $longitude, $unit)
-        ->where(sprintf('Distance %s ?', $comparison), $distance, PDO::PARAM_STR)
+        ->withColumn($preparedSql, 'Distance')
+        ->where(sprintf('%s %s ?', $preparedSql, $comparison), $distance, PDO::PARAM_STR)
         ;
 }


### PR DESCRIPTION
In MySQL you can't use WHERE with a generated column, so using filterByDistanceFrom with the new 'Distance'-column crashes:
"Unable to execute SELECT statement 
[SELECT *, ABS(6371 \* ACOS(x \* COS(RADIANS(lat)) \* COS(RADIANS(lng) - y) + z \* SIN(RADIANS(lat)))) AS `Distance` FROM table WHERE Distance < :p1] 
[wrapped: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Distance' in 'where clause']"

Even the HAVING-clause, which works with newer MySQL versions could be used in this context, does not work with older versions.
So due to compatibility issues I think this file should be reverted (even if that means duplicated code...)
